### PR TITLE
Jsonのフィールド名をスネークケースに統一する

### DIFF
--- a/src/main/kotlin/jp/matsuura/model/response/AuthResponse.kt
+++ b/src/main/kotlin/jp/matsuura/model/response/AuthResponse.kt
@@ -1,7 +1,11 @@
 package jp.matsuura.model.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class AuthResponse(
     val message: String,
+    @JsonProperty("access_token")
     val accessToken: String,
+    @JsonProperty("refresh_token")
     val refreshToken: String,
 )


### PR DESCRIPTION
- #1